### PR TITLE
Allow payable(address) syntax

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -264,6 +264,7 @@ primaryExpression
   | stringLiteral
   | identifier ('[' ']')?
   | TypeKeyword
+  | PayableKeyword
   | tupleExpression
   | typeNameExpression ('[' ']')? ;
 

--- a/test.sol
+++ b/test.sol
@@ -737,3 +737,10 @@ contract Base2 is Destructible {
 contract Final is Base1, Base2 {
     function destroy() public override(Base1, Base2) { super.destroy(); }
 }
+
+contract PayableAddress {
+    function payableFn() public pure {
+        address x;
+        address y = payable(x);
+    }
+}


### PR DESCRIPTION
Hi :)

This...
```solidity
address x;
address y = payable(x);
```
currently crashes with
```
extraneous input 'payable' expecting {'~', 'from', '(', '[', 'address', 'calldata', 'var', 'bool', 'string', 'byte', '++', '--', 'new', '+', '-', 'after', 'delete', '!', Int, Uint, Byte, Fixed, Ufixed, BooleanLiteral, DecimalNumber, HexNumber, HexLiteral, 'type', Identifier, StringLiteralFragment} (54:16)
      at Object.parse (node_modules/solidity-parser-diligence/dist/index.js:79:11)
```

**Notes**
+ The official grammar looks like it's missing the relevant syntax rule 
+ Solution proposed here might be a little generic, not sure.
+ Usage is [described in the Solidity docs here][1]


[1]: https://solidity.readthedocs.io/en/latest/types.html#address