### PR TITLE
Global enums and structs for Solidity 0.6 and pragma versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 
 # solidity-antlr4
 
-Solidity grammar for ANTLR4.com/
+Solidity grammar for [ANTLR (ANother Tool for Language Recognition) ](https://www.antlr.org/)
 
 Now maintained by the ConsenSys Diligence team! :tada:
+
+## Build
+
+Run [build.sh](./build.sh) to download ANTLR jar file and compile the [Solidity.g4](./Solidity.g4) file.
+
+## Tests
+
+Run [run-tests.sh](./run-tests.sh) to parse [test.sol](./test.sol).
 
 ## Authors
 

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -23,7 +23,8 @@ versionOperator
   : '^' | '~' | '>=' | '>' | '<' | '<=' | '=' ;
 
 versionConstraint
-  : versionOperator? VersionLiteral ;
+  : versionOperator? VersionLiteral
+  | versionOperator? DecimalNumber ;
 
 importDeclaration
   : identifier ('as' identifier)? ;

--- a/Solidity.g4
+++ b/Solidity.g4
@@ -5,7 +5,7 @@
 grammar Solidity;
 
 sourceUnit
-  : (pragmaDirective | importDirective | contractDefinition)* EOF ;
+  : (pragmaDirective | importDirective | contractDefinition | enumDefinition | structDefinition)* EOF ;
 
 pragmaDirective
   : 'pragma' pragmaName pragmaValue ';' ;

--- a/test.sol
+++ b/test.sol
@@ -8,7 +8,7 @@ pragma solidity <=0.4.4;
 pragma solidity =0.4.4;
 pragma solidity 0.4;
 pragma solidity >=0.5.0 <0.7.0;
-pragma solidity 0.6;
+pragma solidity ^0.6;
 pragma experimental ABIEncoderV2;
 
 library a {}

--- a/test.sol
+++ b/test.sol
@@ -8,6 +8,8 @@ pragma solidity <=0.4.4;
 pragma solidity =0.4.4;
 pragma solidity 0.4;
 pragma solidity >=0.5.0 <0.7.0;
+pragma solidity 0.6;
+pragma experimental ABIEncoderV2;
 
 library a {}
 library b {}
@@ -742,5 +744,49 @@ contract PayableAddress {
     function payableFn() public pure {
         address x;
         address y = payable(x);
+    }
+}
+
+// Solidity 0.6
+enum Locations {
+    Continent,
+    Empire,
+    Union,
+    Country,
+    State,
+    City,
+    Council,
+    Village
+}
+
+struct KeyValuePair {
+    string name;
+    int256 value;
+}
+
+struct GlobalBaseStruct {
+    KeyValuePair[] pairs;
+    Locations location;
+}
+
+
+contract VirtualA {
+    GlobalBaseStruct base;
+    event MyEvent(string _myString);
+    function funA() public virtual {
+        emit MyEvent("from A");
+    }
+}
+
+contract VirtualB {
+    function funA() public virtual {
+        //does nothing
+    }
+}
+
+contract VirtualOverdide is VirtualA, VirtualB {
+    function funA() public override(VirtualB,VirtualA) {
+        emit MyEvent("from B");
+        super.funA();
     }
 }


### PR DESCRIPTION
- @fvictorio's suggestion in https://github.com/ConsenSys/solidity-antlr4/issues/4 to fix global enums and structs in Solidity 0.6  works
- Fixed pragma versions with an operator and only two numbers. eg ^0.6